### PR TITLE
- Method isICBM added to all components that takes a string as argume…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,39 @@ You can access the component by placing an [adapter](https://ocdoc.cil.li/block:
 - EMP Station
 
 See the code snippets below for what functionality you can use.
+
+### Accesing the components
+By address
+
+```lua
+local component = require("component")
+local proxy = component.proxy("xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+```
+
+By searching through the components on component_name
+```lua
+local component = require("component")
+local proxy = nil
+
+-- Possible values: 
+-- "component_missile_launcher", 
+-- "component_emp_tower",
+-- "component_radar_station", 
+-- "component_cruise_launcher"
+local component_name = "component_missile_launcher" 
+
+for k,v in component.list() do
+  local p = component.proxy(k)
+  if not (p.isICBM == nil) and p.isICBM(component_name) then
+    proxy = p
+  end
+end
+```
  
 ## Know issues
 - Missile launcher adapter changes address after save reload.
+
+
 
 ## Code Snippets
 <details>
@@ -107,7 +137,9 @@ print("The current radius is:")
 print(proxy.getRadius())
  
 print("Activating the emp:")
-print(proxy.launch())
+if proxy.isReady() then
+    print(proxy.launch())
+end
 ```
 
 </details>
@@ -173,7 +205,7 @@ local function contains(uuid, list)
 end
  
 local function loop()
-  local missiles = radar.getIncomingMissiles()
+  local missiles = radar.getMissiles()
   local new_missiles = {}
    
   for index, value in ipairs(missiles) do

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "1.0"
+version = "1.1"
 group = "eternalsoap.icbm.opencomputers" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "OpenComputersICBMAddon"
 

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/CruiseLauncherDriver.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/CruiseLauncherDriver.java
@@ -7,6 +7,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+/**
+ * Driver for {@link TileCruiseLauncher}
+ */
 public class CruiseLauncherDriver extends DriverSidedTileEntity {
 
     @Override

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/CruiseLauncherEnvironment.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/CruiseLauncherEnvironment.java
@@ -15,6 +15,10 @@ public class CruiseLauncherEnvironment extends FrequencyEnvironment<TileCruiseLa
         super(tileEntity, "component_cruise_launcher");
     }
 
+    @Callback(doc = "function(s:string):boolean -- Method for finding this component when looping through the component list, returns true iff s. == \"component_cruise_launcher\"")
+    public Object[] isICBM(final Context context, final Arguments arguments) {
+        return new Object[]{arguments.checkString(0).equals("component_cruise_launcher")};
+    }
 
     @Callback(doc = "function():number -- Get the X & Z coordinate of the target position")
     public Object[] getTargetPos(final Context context, final Arguments args) {

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/EMPDriver.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/EMPDriver.java
@@ -7,6 +7,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+/**
+ * Driver for {@link TileEMPTower}
+ */
 public class EMPDriver extends DriverSidedTileEntity {
 
     @Override

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/EMPEnvironment.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/EMPEnvironment.java
@@ -12,18 +12,28 @@ public class EMPEnvironment extends ManagedTileEntityEnvironment<TileEMPTower> {
         super(tileEntity, "component_emp_tower");
     }
 
-    @Callback(doc = "function():number -- Get the Radius of the launcher, only works when the tier supports the Radius")
+    @Callback(doc = "function(s:string):boolean -- Method for finding this component when looping through the component list, returns true iff s == \"component_emp_tower\"")
+    public Object[] isICBM(final Context context, final Arguments arguments) {
+        return new Object[]{arguments.checkString(0).equals("component_emp_tower")};
+    }
+
+    @Callback(doc = "function():number -- Get the Radius of the EMP Tower")
     public Object[] getRadius(final Context context, final Arguments args) {
         return new Object[]{tileEntity.empRadius};
     }
 
-    @Callback(doc = "function(r:number):boolean -- Set the Radius of the launcher, only works when the tier supports the Radius")
+    @Callback(doc = "function(r:number):boolean -- Set the Radius of the EMP Tower.")
     public Object[] setRadius(final Context context, final Arguments args) {
         tileEntity.empRadius = (args.checkInteger(0));
         return null;
     }
 
-    @Callback(doc = "function():boolean -- Activate the EMP Tower")
+    @Callback(doc = "function():boolean -- Returns true if the EMP tower is ready to fire an EMP")
+    public Object[] isReady(final Context context, final Arguments args) {
+        return new Object[]{tileEntity.isReady()};
+    }
+
+    @Callback(doc = "function():boolean -- Activate the EMP Tower, returns true if it successfully fired, false otherwise ")
     public Object[] launch(final Context context, final Arguments args) {
         if (tileEntity.isReady()) {
             tileEntity.fire();
@@ -37,21 +47,20 @@ public class EMPEnvironment extends ManagedTileEntityEnvironment<TileEMPTower> {
         return new Object[]{tileEntity.empMode};
     }
 
-    @Callback(doc = "function(mode:number):number -- Activate the EMP Tower")
+    @Callback(doc = "function(mode:number):number -- Set the mode of the EMP Tower, 0 = Both, 1 = Missile, 2 = Energy")
     public Object[] setMode(final Context context, final Arguments args) {
-        if (args.isInteger(0)) {
-            switch (args.checkInteger(0)) {
-                case 0:
-                    tileEntity.empMode = (byte) 0;
-                    break;
-                case 1:
-                    tileEntity.empMode = (byte) 1;
-                    break;
-                case 2:
-                    tileEntity.empMode = (byte) 2;
-                    break;
-                default:
-            }
+        switch (args.checkInteger(0)) {
+            case 0:
+                tileEntity.empMode = (byte) 0;
+                break;
+            case 1:
+                tileEntity.empMode = (byte) 1;
+                break;
+            case 2:
+                tileEntity.empMode = (byte) 2;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid mode, Mode should be 0, 1 or 2");
         }
         return null;
     }

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/FrequencyEnvironment.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/FrequencyEnvironment.java
@@ -19,9 +19,7 @@ public abstract class FrequencyEnvironment<T extends TileFrequency> extends Mana
 
     @Callback(doc = "function():number -- Set the Frequency the device operates on")
     public Object[] setFrequency(final Context context, final Arguments args) {
-        if (args.isInteger(0)) {
-            tileEntity.setFrequency(args.checkInteger(0));
-        }
+        tileEntity.setFrequency(args.checkInteger(0));
         return null;
     }
 }

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/LauncherDriver.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/LauncherDriver.java
@@ -7,6 +7,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+/**
+ * Driver for {@link TileLauncherBase}
+ */
 public class LauncherDriver extends DriverSidedTileEntity {
 
     @Override

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/LauncherEnvironment.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/LauncherEnvironment.java
@@ -3,6 +3,7 @@ package com.eternalsoap.icbmopencomputersaddon.drivers;
 import com.eternalsoap.icbmopencomputersaddon.util.ManagedTileEntityEnvironment;
 import icbm.classic.content.machines.launcher.base.TileLauncherBase;
 import icbm.classic.lib.transform.vector.Pos;
+import icbm.classic.prefab.tile.EnumTier;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -10,10 +11,18 @@ import li.cil.oc.api.machine.Context;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The launcher environment for {@link TileLauncherBase}
+ */
 public class LauncherEnvironment extends ManagedTileEntityEnvironment<TileLauncherBase> {
 
     public LauncherEnvironment(TileLauncherBase launcherBase) {
         super(launcherBase, "component_missile_launcher");
+    }
+
+    @Callback(doc = "function(s:string):boolean -- Method for finding this component when looping through the component list, returns true iff s == \"component_missile_launcher\"")
+    public Object[] isICBM(final Context context, final Arguments arguments) {
+        return new Object[]{arguments.checkString(0).equals("component_missile_launcher")};
     }
 
     @Callback(doc = "function():number -- Get the X & Z coordinate of the target position")
@@ -24,33 +33,41 @@ public class LauncherEnvironment extends ManagedTileEntityEnvironment<TileLaunch
         return new Object[]{map};
     }
 
-    @Callback(doc = "function(x: number,z: number) -- Set the X & Z coordinate of the target position")
+    @Callback(doc = "function(x: number, z: number) -- Set the X & Z coordinate of the target position")
     public Object[] setTargetPos(final Context context, final Arguments args) {
         tileEntity.launchScreen.setTarget(new Pos(args.checkInteger(0), tileEntity.launchScreen.getTarget().yi(), args.checkInteger(1)));
         return null;
     }
 
-    @Callback(doc = "function(y: number) -- The y coordinate")
+    @Callback(doc = "function(y: number) -- Sets the detonation height for tier 2 & tier 3 launchers, will not work on tier 1 launchers")
     public Object[] setDetonationHeight(final Context context, final Arguments args) {
-        if (this.tileEntity.getTier().ordinal() >= 1)
-            tileEntity.launchScreen.setTarget(new Pos(tileEntity.launchScreen.getTarget().xi(), args.checkInteger(0), tileEntity.launchScreen.getTarget().zi()));
+        if (this.tileEntity.getTier() == EnumTier.ONE) {
+            throw new IllegalArgumentException("Setting the Detonation-Height is not supported on launchers of tier 1");
+        }
+        tileEntity.launchScreen.setTarget(new Pos(tileEntity.launchScreen.getTarget().xi(), args.checkInteger(0), tileEntity.launchScreen.getTarget().zi()));
         return null;
     }
 
-    @Callback(doc = "function() -- The y coordinate")
+    @Callback(doc = "function(): number -- Gets the detonation height for tier 2 & tier 3 launchers, will not work on tier 1 launchers")
     public Object[] getDetonationHeight(final Context context, final Arguments args) {
+        if (this.tileEntity.getTier() == EnumTier.ONE) {
+            throw new IllegalArgumentException("Getting the Detonation-Height is not supported on launchers of tier 1");
+        }
         return new Object[]{tileEntity.launchScreen.getTarget().yi()};
     }
 
+    /**
+     * Alias for {@link #launchMissile(Context, Arguments)}
+     */
     @Callback(doc = "function(x: number,z: number):boolean -- Launch missile at stored position or by providing the x and z coordinates")
     public Object[] launch(final Context context, final Arguments args) {
         return launchMissile(context, args);
     }
 
-    @Callback(doc = "function(x: number,z: number):boolean -- Launch missile at stored position or by providing the x and z coordinates")
+    @Callback(doc = "function(x: number,z: number):boolean -- Launch missile towards the x and z coordinates, if no coordinates are specified use the coordinates set by setTargetPos")
     public Object[] launchMissile(final Context context, final Arguments args) {
         Pos target = tileEntity.launchScreen.getTarget();
-        if (args.isInteger(0) && args.isInteger(1)) {
+        if (args.isInteger(0)) {
             target = new Pos(args.checkInteger(0), args.checkInteger(1));
         }
         int lockHeight = tileEntity.launchScreen.lockHeight;
@@ -58,23 +75,20 @@ public class LauncherEnvironment extends ManagedTileEntityEnvironment<TileLaunch
         return new Object[]{launchMissile};
     }
 
-    @Callback(doc = "function():boolean -- Checks whether a missile is contained inside the launcher base")
+    @Callback(doc = "function():boolean -- Checks whether a missile is loaded inside the launcher")
     public Object[] containsMissile(final Context context, final Arguments args) {
         return new Object[]{!tileEntity.getMissileStack().isEmpty()};
     }
 
-    @Callback(doc = "function():number -- Get the range of the current missile launcher")
+    @Callback(doc = "function():number -- Get the maximum of the missile launcher")
     public Object[] getRange(final Context context, final Arguments args) {
         return new Object[]{tileEntity.getRange()};
     }
 
     @Callback(doc = "function(x: number,z: number):boolean -- Get whether the given position is within range.")
     public Object[] isInRange(final Context context, final Arguments args) {
-        if (args.isInteger(0) && args.isInteger(1)) {
-            Pos target = new Pos(args.checkInteger(0), args.checkInteger(1));
-            return new Object[]{tileEntity.isInRange(target)};
-        }
-        return new Object[]{false};
+        Pos target = new Pos(args.checkInteger(0), args.checkInteger(1));
+        return new Object[]{tileEntity.isInRange(target)};
     }
 
     @Callback(doc = "function():number -- Get the inaccuracy of the current missile launcher")
@@ -88,23 +102,50 @@ public class LauncherEnvironment extends ManagedTileEntityEnvironment<TileLaunch
 
     @Callback(doc = "function():number -- Get the Frequency of the launcher, only works when the tier supports the frequency")
     public Object[] getFrequency(final Context context, final Arguments args) {
+        if (this.tileEntity.getTier() == EnumTier.ONE || this.tileEntity.getTier() == EnumTier.TWO) {
+            throw new IllegalArgumentException("Getting the frequency is not supported on launchers of tier 1 and tier 2");
+        }
         return new Object[]{tileEntity.launchScreen.getFrequency()};
     }
 
     @Callback(doc = "function(number):boolean -- Set the Frequency of the launcher, only works when the tier supports the frequency")
     public Object[] setFrequency(final Context context, final Arguments args) {
+        if (this.tileEntity.getTier() == EnumTier.ONE || this.tileEntity.getTier() == EnumTier.TWO) {
+            throw new IllegalArgumentException("Setting the frequency is not supported on launchers of tier 1 and tier 2");
+        }
         tileEntity.launchScreen.setFrequency(args.checkInteger(0));
         return null;
     }
 
     @Callback(doc = "function():number -- Get the LockHeight of the launcher, only works when the tier supports the LockHeight")
     public Object[] getLockHeight(final Context context, final Arguments args) {
+        if (this.tileEntity.getTier() == EnumTier.ONE) {
+            throw new IllegalArgumentException("Getting the Lock-Height is not supported on launchers of tier 1");
+        }
         return new Object[]{tileEntity.launchScreen.lockHeight};
     }
 
     @Callback(doc = "function(number):boolean -- Set the LockHeight of the launcher, only works when the tier supports the LockHeight")
     public Object[] setLockHeight(final Context context, final Arguments args) {
+        if (this.tileEntity.getTier() == EnumTier.ONE) {
+            throw new IllegalArgumentException("Setting the Lock-Height is not supported on launchers of tier 1");
+        }
         tileEntity.launchScreen.lockHeight = (short) (args.checkInteger(0));
         return null;
+    }
+
+    @Callback(doc = "function():number -- Get the tier of the launcher, [1,2,3]")
+    public Object[] getTier(final Context context, final Arguments args) {
+        switch (this.tileEntity.getTier()) {
+            case ONE:
+                return new Object[]{1};
+            case TWO:
+                return new Object[]{2};
+            case THREE:
+                return new Object[]{3};
+            default:
+                return null;
+        }
+
     }
 }

--- a/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/RadarDriver.java
+++ b/src/main/java/com/eternalsoap/icbmopencomputersaddon/drivers/RadarDriver.java
@@ -7,6 +7,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+/**
+ * Driver for {@link TileRadarStation}
+ */
 public class RadarDriver extends DriverSidedTileEntity {
 
     @Override


### PR DESCRIPTION
…nt to search for this component in the component.list() method

- Radar: Missile UUID is now not the same as the entity UUID. This is so that you can't "cheat" by using this UUID
- Radar: Now throws error in invalid arguments by setAlarmRange and setSafetyRange
- Missile Launcher: Added a getTier method
- Missile launcher: lockHeight, frequency, and detonation_height functions now will throw error if they are called on a launcher tier that does not support this functionality
- Cruise Launcher & Radar: setFrequency will now throw error if there is an invalid argument
- EMP Tower: Will now throw an error if setMode is called with invalid argument